### PR TITLE
IoT Edge module fix: latest Mosquitto does not support anonymous access

### DIFF
--- a/deploy/deployment.demo.json
+++ b/deploy/deployment.demo.json
@@ -55,7 +55,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "eclipse-mosquitto:latest",
+              "image": "eclipse-mosquitto:1.6",
               "createOptions": "{\"ExposedPorts\":{\"1883/tcp\":{}},\"HostConfig\":{\"PortBindings\":{\"1883/tcp\":[{\"HostPort\":\"1883\"}]}}}"
             }
           }

--- a/src/edge/deployment.debug.template.json
+++ b/src/edge/deployment.debug.template.json
@@ -80,7 +80,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "eclipse-mosquitto:latest",
+              "image": "eclipse-mosquitto:1.6",
               "createOptions": {
                 "ExposedPorts": {
                   "1883/tcp": {}

--- a/src/edge/deployment.demo.template.json
+++ b/src/edge/deployment.demo.template.json
@@ -73,7 +73,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "eclipse-mosquitto:latest",
+              "image": "eclipse-mosquitto:1.6",
               "createOptions": {
                 "ExposedPorts": {
                   "1883/tcp": {}


### PR DESCRIPTION
The `eclipse-mosquitto:latest`container image that was referenced turns out to be v2.x, which no longer allows anonymous access (https://mosquitto.org/documentation/migrating-to-2-0/, see section 'Authentication requires configuration').

Since this is a POC focused on Protocol & Identity Translation, I figured a straight-forward solution would be to specify an older Mosquitto version instead (specifically, v1.6), to get things working again.